### PR TITLE
mnemonic recovery: add dynamic Sapling account discovery

### DIFF
--- a/zexcavator-tui/src/views/sync.rs
+++ b/zexcavator-tui/src/views/sync.rs
@@ -478,4 +478,27 @@ mod tests {
             );
         }
     }
+
+    mod expansion_predicate {
+        use super::super::needs_account_expansion;
+        #[test]
+        fn no_activity_does_not_expand() {
+            assert!(!needs_account_expansion(None, 10, 5));
+        }
+
+        #[test]
+        fn activity_below_threshold_does_not_expand() {
+            assert!(!needs_account_expansion(Some(4), 10, 5));
+        }
+
+        #[test]
+        fn activity_at_threshold_expands() {
+            assert!(needs_account_expansion(Some(5), 10, 5));
+        }
+
+        #[test]
+        fn saturating_sub_edge_case_expands() {
+            assert!(needs_account_expansion(Some(0), 3, 5));
+        }
+    }
 }

--- a/zexcavator-tui/src/views/sync.rs
+++ b/zexcavator-tui/src/views/sync.rs
@@ -501,4 +501,44 @@ mod tests {
             assert!(needs_account_expansion(Some(0), 3, 5));
         }
     }
+
+    mod discovery_loop {
+        use super::super::needs_account_expansion;
+
+        /// Test-only helper that simulates repeated account-window expansion
+        /// decisions from canned per-round `highest_active` values.
+        fn simulate_discovery(initial_window: u32, gap_limit: u32, rounds: &[Option<u32>]) -> u32 {
+            let mut window = initial_window;
+            for highest_active in rounds {
+                if !needs_account_expansion(*highest_active, window, gap_limit) {
+                    break;
+                }
+                window += gap_limit;
+            }
+            window
+        }
+
+        #[test]
+        fn no_activity_no_expansion() {
+            assert_eq!(simulate_discovery(10, 5, &[None]), 10);
+        }
+
+        #[test]
+        fn one_expansion_then_settles() {
+            // Round 0: window=10, highest=8, threshold=5 → 8 >= 5 → expand to 15
+            // Round 1: window=15, highest=8, threshold=10 → 8 < 10 → stop
+            assert_eq!(simulate_discovery(10, 5, &[Some(8), Some(8)]), 15);
+        }
+
+        #[test]
+        fn two_expansions_then_settles() {
+            // Round 0: window=10, highest=7, threshold=5 → 7 >= 5 → expand to 15
+            // Round 1: window=15, highest=12, threshold=10 → 12 >= 10 → expand to 20
+            // Round 2: window=20, highest=12, threshold=15 → 12 < 15 → stop
+            assert_eq!(
+                simulate_discovery(10, 5, &[Some(7), Some(12), Some(12)]),
+                20
+            );
+        }
+    }
 }

--- a/zexcavator-tui/src/views/sync.rs
+++ b/zexcavator-tui/src/views/sync.rs
@@ -337,22 +337,25 @@ impl SyncView {
             );
         }
 
-        // Report balance from account 0 (multi-account aggregation is a follow-up)
-        let balances = light_client
-            .wallet
-            .lock()
-            .await
-            .account_balance(zip32::AccountId::try_from(0).unwrap())
-            .await
-            .unwrap();
-        let final_balance = balances.total_transparent_balance.unwrap()
-            + balances.total_sapling_balance.unwrap()
-            + balances.total_orchard_balance.unwrap();
-        let balance_in_zec = final_balance.unwrap() / NonZero::new(10u64.pow(8)).unwrap();
+        // Report total balance across all accounts
+        let wallet_guard = light_client.wallet.lock().await;
+        let mut total_zat: u64 = 0;
+        for i in 0..no_of_accounts {
+            let account_id = zip32::AccountId::try_from(i).unwrap();
+            if let Ok(b) = wallet_guard.account_balance(account_id).await {
+                let pool_sum = b.total_transparent_balance.unwrap()
+                    + b.total_sapling_balance.unwrap()
+                    + b.total_orchard_balance.unwrap();
+                if let Some(zat) = pool_sum {
+                    total_zat += u64::from(zat);
+                }
+            }
+        }
+        drop(wallet_guard);
         self.log_buffer
             .lock()
             .unwrap()
-            .push(format!("Total ZEC found: {}", balance_in_zec.into_u64()));
+            .push(format!("Total ZEC found: {}", total_zat / 10u64.pow(8)));
         *self.sync_complete.lock().unwrap() = true;
 
         light_client
@@ -457,21 +460,24 @@ mod tests {
                 vec.mnemonic, vec.birthday
             );
 
-            let balances = client
-                .wallet
-                .lock()
-                .await
-                .account_balance(zip32::AccountId::try_from(0).unwrap())
-                .await
-                .unwrap();
-            let final_balance = balances.total_transparent_balance.unwrap()
-                + balances.total_sapling_balance.unwrap()
-                + balances.total_orchard_balance.unwrap();
-            let balance_in_zec = final_balance.unwrap() / NonZero::new(10u64.pow(8)).unwrap();
+            let wallet_guard = client.wallet.lock().await;
+            let mut total_zat: u64 = 0;
+            for acct in 0..5u32 {
+                let account_id = zip32::AccountId::try_from(acct).unwrap();
+                if let Ok(b) = wallet_guard.account_balance(account_id).await {
+                    let pool_sum = b.total_transparent_balance.unwrap()
+                        + b.total_sapling_balance.unwrap()
+                        + b.total_orchard_balance.unwrap();
+                    if let Some(zat) = pool_sum {
+                        total_zat += u64::from(zat);
+                    }
+                }
+            }
+            drop(wallet_guard);
 
             println!(
                 "Vector {i} passed! Found balance: {} ZEC",
-                balance_in_zec.into_u64()
+                total_zat / 10u64.pow(8)
             );
         }
     }

--- a/zexcavator-tui/src/views/sync.rs
+++ b/zexcavator-tui/src/views/sync.rs
@@ -306,10 +306,8 @@ impl SyncView {
                 .map(|note| u32::from(note.key_id().account_id))
                 .max();
 
-            let needs_expansion = match highest_active {
-                Some(h) => h >= no_of_accounts.saturating_sub(GAP_LIMIT),
-                None => false,
-            };
+            let needs_expansion =
+                needs_account_expansion(highest_active, no_of_accounts, GAP_LIMIT);
 
             if !needs_expansion {
                 break;
@@ -405,6 +403,13 @@ impl Renderable for SyncView {
             .split(f.area());
         app.view(&Id::ProgressBar, f, chunks[0]);
         app.view(&Id::SyncLog, f, chunks[1]);
+    }
+}
+
+fn needs_account_expansion(highest_active: Option<u32>, window: u32, gap_limit: u32) -> bool {
+    match highest_active {
+        Some(h) => h >= window.saturating_sub(gap_limit),
+        None => false,
     }
 }
 

--- a/zexcavator-tui/src/views/sync.rs
+++ b/zexcavator-tui/src/views/sync.rs
@@ -215,39 +215,14 @@ impl SyncView {
                 .push(format!("Error installing crypto provider: {:?}", e));
         }
 
-        let zc = load_clientconfig(
-            Uri::from_static(DEFAULT_LIGHTWALLETD_SERVER),
-            None,
-            ChainType::Mainnet,
-            WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::recovery(),
-                },
-            },
-            NonZero::new(1).unwrap(),
-        )
-        .unwrap();
-
-        let mnemonic = Mnemonic::<English>::from_str(&mnemonic_str).unwrap();
-
         let birthday = birthday.unwrap_or_default();
-
-        let lw = LightWallet::new(
-            ChainType::Mainnet,
-            WalletBase::Mnemonic {
-                mnemonic: mnemonic,
-                no_of_accounts: NonZero::new(1).unwrap(),
+        let wallet_settings = WalletSettings {
+            sync_config: SyncConfig {
+                transparent_address_discovery: TransparentAddressDiscovery::recovery(),
             },
-            birthday.into(),
-            WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::recovery(),
-                },
-            },
-        )
-        .unwrap();
-
-        let mut light_client = LightClient::create_from_wallet(lw, zc, true).unwrap();
+        };
+        let mut light_client =
+            self.create_mnemonic_client(&mnemonic_str, birthday, 1, &wallet_settings);
 
         self.log_buffer
             .lock()
@@ -349,6 +324,34 @@ impl SyncView {
         }
 
         light_client
+    }
+
+    fn create_mnemonic_client(
+        &self,
+        mnemonic_str: &str,
+        birthday: u32,
+        no_of_accounts: u32,
+        wallet_settings: &WalletSettings,
+    ) -> LightClient {
+        let zc = load_clientconfig(
+            Uri::from_static(DEFAULT_LIGHTWALLETD_SERVER),
+            None,
+            ChainType::Mainnet,
+            wallet_settings.clone(),
+            NonZero::new(no_of_accounts).unwrap(),
+        )
+        .unwrap();
+        let lw = LightWallet::new(
+            ChainType::Mainnet,
+            WalletBase::Mnemonic {
+                mnemonic: Mnemonic::<English>::from_str(mnemonic_str).unwrap(),
+                no_of_accounts: NonZero::new(no_of_accounts).unwrap(),
+            },
+            birthday.into(),
+            wallet_settings.clone(),
+        )
+        .unwrap();
+        LightClient::create_from_wallet(lw, zc, true).unwrap()
     }
 }
 

--- a/zexcavator-tui/src/views/sync.rs
+++ b/zexcavator-tui/src/views/sync.rs
@@ -8,6 +8,7 @@ use bip0039::{English, Mnemonic};
 use http::Uri;
 use pepper_sync::sync::{SyncConfig, TransparentAddressDiscovery};
 use pepper_sync::sync_status;
+use pepper_sync::wallet::OutputInterface;
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
 use tuirealm::{Application, Frame, NoUserEvent};
 use zingolib::config::{ChainType, DEFAULT_LIGHTWALLETD_SERVER, load_clientconfig};
@@ -208,6 +209,9 @@ impl SyncView {
         mnemonic_str: String,
         birthday: Option<u32>,
     ) -> LightClient {
+        const INITIAL_WINDOW: u32 = 10;
+        const GAP_LIMIT: u32 = 5;
+
         if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
             self.log_buffer
                 .lock()
@@ -221,107 +225,135 @@ impl SyncView {
                 transparent_address_discovery: TransparentAddressDiscovery::recovery(),
             },
         };
-        let mut light_client =
-            self.create_mnemonic_client(&mnemonic_str, birthday, 1, &wallet_settings);
+        let mut no_of_accounts = INITIAL_WINDOW;
+        let mut light_client = self
+            .create_mnemonic_client(&mnemonic_str, birthday, no_of_accounts, &wallet_settings);
 
+        loop {
+            self.log_buffer.lock().unwrap().push(format!(
+                "Scanning {} account(s) from birthday {}",
+                no_of_accounts, birthday
+            ));
+
+            // Sync and poll until complete
+            match light_client.sync().await {
+                Ok(_) => {}
+                Err(e) => self
+                    .log_buffer
+                    .lock()
+                    .unwrap()
+                    .push(format!("Error starting sync: {}", e)),
+            }
+
+            let mut interval = tokio::time::interval(Duration::from_secs(1));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                interval.tick().await;
+                match light_client.poll_sync() {
+                    PollReport::NoHandle => (),
+                    PollReport::NotReady => {
+                        let wallet = light_client.wallet.lock().await;
+                        match sync_status(&*wallet).await {
+                            Ok(status) => {
+                                self.log_buffer
+                                    .lock()
+                                    .unwrap()
+                                    .push(format!("{}", status));
+                                *self.progress.lock().unwrap() =
+                                    status.percentage_total_outputs_scanned;
+                            }
+                            Err(e) => {
+                                self.log_buffer
+                                    .lock()
+                                    .unwrap()
+                                    .push(format!("{}", e));
+                                continue;
+                            }
+                        };
+                    }
+                    PollReport::Ready(result) => match result {
+                        Ok(sync_result) => {
+                            self.log_buffer
+                                .lock()
+                                .unwrap()
+                                .push(format!("Sync result: {:?}", sync_result));
+                            break;
+                        }
+                        Err(_e) => {
+                            self.log_buffer
+                                .lock()
+                                .unwrap()
+                                .push("Error. Resuming sync".to_string());
+                            match light_client.sync().await {
+                                Ok(_) => self
+                                    .log_buffer
+                                    .lock()
+                                    .unwrap()
+                                    .push("Sync resumed".to_string()),
+                                Err(e) => self
+                                    .log_buffer
+                                    .lock()
+                                    .unwrap()
+                                    .push(format!("{}", e)),
+                            }
+                            continue;
+                        }
+                    },
+                }
+            }
+
+            // Check highest account with any sapling note history (including spent)
+            let highest_active: Option<u32> = light_client
+                .wallet
+                .lock()
+                .await
+                .wallet_transactions
+                .values()
+                .flat_map(|tx| tx.sapling_notes())
+                .map(|note| u32::from(note.key_id().account_id))
+                .max();
+
+            let needs_expansion = match highest_active {
+                Some(h) => h >= no_of_accounts.saturating_sub(GAP_LIMIT),
+                None => false,
+            };
+
+            if !needs_expansion {
+                break;
+            }
+
+            // Recreate wallet with a larger account window
+            no_of_accounts += GAP_LIMIT;
+            self.log_buffer.lock().unwrap().push(format!(
+                "Activity near bound (highest: {}), expanding to {} accounts",
+                highest_active.unwrap(),
+                no_of_accounts
+            ));
+            light_client = self.create_mnemonic_client(
+                &mnemonic_str,
+                birthday,
+                no_of_accounts,
+                &wallet_settings,
+            );
+        }
+
+        // Report balance from account 0 (multi-account aggregation is a follow-up)
+        let balances = light_client
+            .wallet
+            .lock()
+            .await
+            .account_balance(zip32::AccountId::try_from(0).unwrap())
+            .await
+            .unwrap();
+        let final_balance = balances.total_transparent_balance.unwrap()
+            + balances.total_sapling_balance.unwrap()
+            + balances.total_orchard_balance.unwrap();
+        let balance_in_zec = final_balance.unwrap() / NonZero::new(10u64.pow(8)).unwrap();
         self.log_buffer
             .lock()
             .unwrap()
-            .push(format!("Starting sync from birthday: {}", birthday));
-        match light_client.sync().await {
-            Ok(_) => self
-                .log_buffer
-                .lock()
-                .unwrap()
-                .push("Sync started".to_string()),
-            Err(e) => self
-                .log_buffer
-                .lock()
-                .unwrap()
-                .push(format!("Error starting syncing: {}", e)),
-        }
-
-        let mut interval = tokio::time::interval(Duration::from_secs(1));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        loop {
-            interval.tick().await;
-            match light_client.poll_sync() {
-                PollReport::NoHandle => (),
-                PollReport::NotReady => {
-                    let wallet = light_client.wallet.lock().await;
-                    match sync_status(&*wallet).await {
-                        Ok(status) => {
-                            self.log_buffer.lock().unwrap().push(format!("{}", status));
-                            *self.progress.lock().unwrap() =
-                                status.percentage_total_outputs_scanned;
-                        }
-                        Err(e) => {
-                            self.log_buffer.lock().unwrap().push(format!("{}", e));
-                            continue;
-                        }
-                    };
-                }
-                PollReport::Ready(result) => match result {
-                    Ok(sync_result) => {
-                        self.log_buffer
-                            .lock()
-                            .unwrap()
-                            .push(format!("Sync result: {:?}", sync_result));
-                        let balances = light_client
-                            .wallet
-                            .lock()
-                            .await
-                            .account_balance(zip32::AccountId::try_from(0).unwrap())
-                            .await
-                            .unwrap();
-                        let final_balance = balances.total_transparent_balance.unwrap()
-                            + balances.total_sapling_balance.unwrap()
-                            + balances.total_orchard_balance.unwrap();
-                        let balance_in_zec =
-                            final_balance.unwrap() / NonZero::new(10u64.pow(8)).unwrap();
-                        self.log_buffer
-                            .lock()
-                            .unwrap()
-                            .push(format!("Total ZEC found: {}", balance_in_zec.into_u64()));
-                        *self.sync_complete.lock().unwrap() = true;
-
-                        break;
-                    }
-                    Err(_e) => {
-                        self.log_buffer
-                            .lock()
-                            .unwrap()
-                            .push("Error. Resuming sync".to_string());
-                        self.log_buffer
-                            .lock()
-                            .unwrap()
-                            .push("Restarting sync".to_string());
-
-                        match light_client.sync().await {
-                            Ok(_) => self
-                                .log_buffer
-                                .lock()
-                                .unwrap()
-                                .push("Sync resumed".to_string()),
-                            Err(e) => self.log_buffer.lock().unwrap().push(format!("{}", e)),
-                        }
-                        continue;
-                    }
-                },
-            }
-        }
-
-        match light_client.sync().await {
-            Ok(_) => {
-                self.log_buffer
-                    .lock()
-                    .unwrap()
-                    .push("Sync finished".to_string());
-            }
-            Err(e) => {
-                self.log_buffer.lock().unwrap().push(format!("{}", e));
-            }
-        }
+            .push(format!("Total ZEC found: {}", balance_in_zec.into_u64()));
+        *self.sync_complete.lock().unwrap() = true;
 
         light_client
     }

--- a/zexcavator-tui/src/views/sync.rs
+++ b/zexcavator-tui/src/views/sync.rs
@@ -11,7 +11,7 @@ use pepper_sync::sync_status;
 use pepper_sync::wallet::OutputInterface;
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
 use tuirealm::{Application, Frame, NoUserEvent};
-use zingolib::config::{ChainType, DEFAULT_LIGHTWALLETD_SERVER, load_clientconfig};
+use zingolib::config::{load_clientconfig, ChainType, DEFAULT_LIGHTWALLETD_SERVER};
 use zingolib::data::PollReport;
 use zingolib::lightclient::{self, LightClient};
 use zingolib::wallet::{LightWallet, WalletBase, WalletSettings};
@@ -226,16 +226,17 @@ impl SyncView {
             },
         };
         let mut no_of_accounts = INITIAL_WINDOW;
-        let mut light_client = self
-            .create_mnemonic_client(&mnemonic_str, birthday, no_of_accounts, &wallet_settings);
+        let mut light_client =
+            self.create_mnemonic_client(&mnemonic_str, birthday, no_of_accounts, &wallet_settings);
 
+        // Sync using the current account window; expand and retry if needed
         loop {
             self.log_buffer.lock().unwrap().push(format!(
                 "Scanning {} account(s) from birthday {}",
                 no_of_accounts, birthday
             ));
 
-            // Sync and poll until complete
+            // Start current wallet sync attempt
             match light_client.sync().await {
                 Ok(_) => {}
                 Err(e) => self
@@ -247,6 +248,8 @@ impl SyncView {
 
             let mut interval = tokio::time::interval(Duration::from_secs(1));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+            // Poll current wallet sync until completion
             loop {
                 interval.tick().await;
                 match light_client.poll_sync() {
@@ -255,18 +258,12 @@ impl SyncView {
                         let wallet = light_client.wallet.lock().await;
                         match sync_status(&*wallet).await {
                             Ok(status) => {
-                                self.log_buffer
-                                    .lock()
-                                    .unwrap()
-                                    .push(format!("{}", status));
+                                self.log_buffer.lock().unwrap().push(format!("{}", status));
                                 *self.progress.lock().unwrap() =
                                     status.percentage_total_outputs_scanned;
                             }
                             Err(e) => {
-                                self.log_buffer
-                                    .lock()
-                                    .unwrap()
-                                    .push(format!("{}", e));
+                                self.log_buffer.lock().unwrap().push(format!("{}", e));
                                 continue;
                             }
                         };
@@ -290,11 +287,7 @@ impl SyncView {
                                     .lock()
                                     .unwrap()
                                     .push("Sync resumed".to_string()),
-                                Err(e) => self
-                                    .log_buffer
-                                    .lock()
-                                    .unwrap()
-                                    .push(format!("{}", e)),
+                                Err(e) => self.log_buffer.lock().unwrap().push(format!("{}", e)),
                             }
                             continue;
                         }
@@ -392,14 +385,13 @@ impl SyncView {
 
 impl Mountable for SyncView {
     fn mount(app: &mut Application<Id, Msg, tuirealm::event::NoUserEvent>) -> anyhow::Result<()> {
-        assert!(
-            app.mount(
+        assert!(app
+            .mount(
                 Id::ProgressBar,
                 Box::new(SyncBar::default()),
                 Vec::default()
             )
-            .is_ok()
-        );
+            .is_ok());
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- add dynamic mnemonic-only Sapling account discovery in `zexcavator`
- start mnemonic recovery with an initial account window of 10
- after each sync, inspect Sapling note history (including spent notes) to find the highest active account
- if activity is near the upper bound, **recreate the wallet/client with a larger account window** and rescan
- aggregate balances across all instantiated accounts after convergence

## Motivation
Historical ZecWallet Lite could create new shielded receive addresses by incrementing the ZIP 32 account index rather than using diversified addresses under a single account.  This means mnemonic-only recovery cannot safely assume account 0 is enough. 

For background on the historical wallet behavior that motivates this recovery path, see Dorian's [ZIP PR #1176](https://github.com/zcash/zips/pull/1176).

`zingolib` does not do shielded account discovery during sync, so `zexcavator` needs to decide how many accounts to instantiate up front. This PR adds a bounded/dynamic retry strategy for the mnemonic-only path.

## Scope
This PR is intentionally narrow:
- mnemonic-only recovery path only
- historical Sapling multi-account recovery only
- no changes to `zingolib` internals
- no changes to wallet-file-guided recovery
- no changes to export flow

## Implementation notes
- uses Sapling note history, not current balance, as the account-activity signal
- counts an account as active if any Sapling note was detected for that account, including spent notes
- on expansion, **recreates the wallet/client from the mnemonic with a larger `no_of_accounts` window rather than relying on `create_new_account()`**

## Main Design Decision:
**Why recreate instead of mutating the wallet?**

I originally explored `create_new_account() + rescan()`, but switched to recreating the wallet/client from the mnemonic because it stays on the better-exercised `LightWallet::new(... no_of_accounts ...)` path and avoids depending on effectively unused account-mutation code.

## Limitations / follow-ups
- each expansion requires a full rescan from birthday
- export view still appears to be account-0-only
- file-based recovery remains separate work
- activity detection is Sapling-only, which is correct for the historical ZecWallet Lite case but not a general Orchard discovery solution

## Testing
- `cargo check`
- added unit tests for the mnemonic account expansion predicate
- investigated `test_mnemonic_vectors_from_file`, but it doesn't provide a clean or fast validation signal in the current live-chain environment
- tracked separately in issue [#62](https://github.com/zingolabs/zexcavator/issues/62)

**Note:** This draft is the mnemonic-only recovery half of related zexcavator work on multi-account recovery.  For wallet-file-based recovery, Evan's PR #59.